### PR TITLE
Unchecked "Circle Collider" component of Student prefabs

### DIFF
--- a/Graduation Game Project/Assets/Prefabs/DoctoralStudent.prefab
+++ b/Graduation Game Project/Assets/Prefabs/DoctoralStudent.prefab
@@ -245,7 +245,7 @@ CircleCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6548965246529103440}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0

--- a/Graduation Game Project/Assets/Prefabs/UndergradStudent.prefab
+++ b/Graduation Game Project/Assets/Prefabs/UndergradStudent.prefab
@@ -258,7 +258,7 @@ CircleCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6132625103161577813}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0


### PR DESCRIPTION
The "Circle Collider" component of Student prefabs is causing the objects to run into eachother if too close, resulting in oscilation.  Unchecked for now in order to target specifically from bullets coming from Towers